### PR TITLE
[OP] Embedding

### DIFF
--- a/ratex/csrc/aten_raf_type.cpp
+++ b/ratex/csrc/aten_raf_type.cpp
@@ -1089,7 +1089,11 @@ at::Tensor LazyNativeFunctions::embedding(const at::Tensor& weight, const at::Te
                                           int64_t padding_idx, bool scale_grad_by_freq,
                                           bool sparse) {
   LTC_FN_COUNTER("raf::");
-  LTC_CHECK(!scale_grad_by_freq && !sparse && padding_idx == -1) << "Unsupported parameters";
+  if (scale_grad_by_freq || sparse || padding_idx != -1) {
+    RATEX_VLOG(3) << "Unsupported parameters - Falling back to CPU (currently sparse, "
+                     "scale_grad_by_freq, and padding are not support)";
+    return FALLBACK_ATEN_OP(embedding, weight, indices, padding_idx, scale_grad_by_freq, sparse);
+  }
   LazyTensor weight_tensor;
   LazyTensor indices_tensor;
   auto weight_xtensor = bridge::raf_backend::TryGetLtcTensor(weight);

--- a/ratex/csrc/aten_raf_type.cpp
+++ b/ratex/csrc/aten_raf_type.cpp
@@ -1089,8 +1089,18 @@ at::Tensor LazyNativeFunctions::embedding(const at::Tensor& weight, const at::Te
                                           int64_t padding_idx, bool scale_grad_by_freq,
                                           bool sparse) {
   LTC_FN_COUNTER("raf::");
-  // We route embedding to native so that it will be decomposed to supported Lazy operations.
-  return at::native::embedding(weight, indices, padding_idx, scale_grad_by_freq, sparse);
+  LazyTensor weight_tensor;
+  LazyTensor indices_tensor;
+  auto weight_xtensor = bridge::raf_backend::TryGetLtcTensor(weight);
+  if (!weight_xtensor) {
+    indices_tensor = bridge::raf_backend::GetLtcTensor(indices);
+    weight_tensor = bridge::GetOrCreateLtcTensor(weight, indices_tensor.GetDevice());
+  } else {
+    weight_tensor = *weight_xtensor;
+    indices_tensor = bridge::GetOrCreateLtcTensor(indices, weight_tensor.GetDevice());
+  }
+  return bridge::AtenFromLtcTensor(LazyTensor::embedding(weight_tensor, indices_tensor, padding_idx,
+                                                         scale_grad_by_freq, sparse));
 }
 
 at::Tensor LazyNativeFunctions::embedding_dense_backward(const at::Tensor& grad_output,

--- a/ratex/lazy_tensor_core/csrc/ops/embedding.cpp
+++ b/ratex/lazy_tensor_core/csrc/ops/embedding.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "lazy_tensor_core/csrc/ops/embedding.h"
+
+#include "lazy_tensor_core/csrc/compiler/node_lowering.h"
+#include "lazy_tensors/computation_client/debug_macros.h"
+#include "lazy_tensors/computation_client/util.h"
+
+namespace torch_lazy_tensors {
+namespace ir {
+namespace ops {
+
+Embedding::Embedding(const Value& weight, const Value& indices)
+    : Node(ir::OpKind(at::aten::embedding), {weight, indices}) {
+  SetShapeDeferred([&]() { return compiler::NodeLowering::Get()->Infer(this); });
+}
+
+NodePtr Embedding::Clone(OpList operands) const {
+  return MakeNode<Embedding>(operands.at(0), operands.at(1));
+}
+
+std::string Embedding::ToString() const {
+  std::stringstream ss;
+  ss << Node::ToString();
+  return ss.str();
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_lazy_tensors

--- a/ratex/lazy_tensor_core/csrc/ops/embedding.h
+++ b/ratex/lazy_tensor_core/csrc/ops/embedding.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "lazy_tensor_core/csrc/ir.h"
+
+namespace torch_lazy_tensors {
+namespace ir {
+namespace ops {
+
+class Embedding : public Node {
+ public:
+  Embedding(const Value& weight, const Value& indices);
+
+  NodePtr Clone(OpList operands) const override;
+
+  std::string ToString() const override;
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_lazy_tensors

--- a/ratex/lazy_tensor_core/csrc/tensor.h
+++ b/ratex/lazy_tensor_core/csrc/tensor.h
@@ -455,6 +455,9 @@ class LazyTensor {
                                  const at::Scalar& scale, const at::Scalar& input_scale,
                                  const LazyTensor& output);
 
+  static LazyTensor embedding(const LazyTensor& weight, const LazyTensor& indices,
+                              int64_t padding_idx, bool scale_grad_by_freq, bool sparse);
+
   static LazyTensor embedding_dense_backward(const LazyTensor& grad_output,
                                              const LazyTensor& indices, int64_t num_weights,
                                              int64_t padding_idx, bool scale_grad_by_freq);

--- a/ratex/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/ratex/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -51,6 +51,7 @@
 #include "lazy_tensor_core/csrc/ops/discrete_uniform.h"
 #include "lazy_tensor_core/csrc/ops/expand.h"
 #include "lazy_tensor_core/csrc/ops/exponential.h"
+#include "lazy_tensor_core/csrc/ops/embedding.h"
 #include "lazy_tensor_core/csrc/ops/flip.h"
 #include "lazy_tensor_core/csrc/ops/gather.h"
 #include "lazy_tensor_core/csrc/ops/generic.h"
@@ -1009,6 +1010,12 @@ LazyTensor LazyTensor::elu_backward(const LazyTensor& grad_output, const at::Sca
                                     const LazyTensor& output) {
   return grad_output.CreateFrom(ir::ops::EluBackward(grad_output.GetIrValue(), output.GetIrValue(),
                                                      alpha, scale, input_scale));
+}
+
+LazyTensor LazyTensor::embedding(const LazyTensor& weight, const LazyTensor& indices,
+                                 int64_t padding_idx, bool scale_grad_by_freq, bool sparse) {
+  return weight.CreateFrom(
+      ir::MakeNode<ir::ops::Embedding>(weight.GetIrValue(), indices.GetIrValue()));
 }
 
 LazyTensor LazyTensor::embedding_dense_backward(const LazyTensor& grad_output,

--- a/tests/python/op/test_nn.py
+++ b/tests/python/op/test_nn.py
@@ -86,5 +86,18 @@ def test_gelu():
     verify_step(Model(), [x])
 
 
+def test_embedding():
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embedding = nn.Embedding(10, 3)
+
+        def forward(self, x_input):
+            return self.embedding(x_input)
+
+    x = torch.randint(10, (3, 3))
+    verify_step(Model(), [x], jit_script=False)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Instead of decomposing embedding into smaller OP we can lower the entire embedding OP to raf embedding. Note that RAF's version of embedding does not accept padding_idx, scale_grad_by_freq, and sparse parameters - these params will be ignored in the current implementation. 

## Checklist ##

- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

cc @awslabs/raf-reviewer @zachzzc 
