### PR TITLE
[OP] Matmul

### DIFF
--- a/raf_native_functions.yaml
+++ b/raf_native_functions.yaml
@@ -303,6 +303,7 @@ supported:
   - sigmoid_backward
   - tanh_backward
   - ger
+  - matmul
 autograd:
   - max_pool2d
   - max_pool3d

--- a/tests/python/op/test_nn.py
+++ b/tests/python/op/test_nn.py
@@ -86,5 +86,23 @@ def test_gelu():
     verify_step(Model(), [x])
 
 
+@pytest.mark.parametrize("shape", [(3, 3, 3)])
+def test_matmul(shape):
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x_input, y_input):
+            return torch.matmul(x_input, y_input)
+
+    for i in range(1, len(shape) + 1):
+        x_s = shape[::i]
+        x = torch.randn(x_s)
+        for j in range(1, len(shape) + 1):
+            y_s = shape[::j]
+            y = torch.randn(y_s)
+            verify_step(Model(), [x, y], jit_script=False)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Matmul lowering for M5 native trace. Matmul OP is currently only around 60% complete (sufficient for M5). It does not natively support conversion of higher dim matrix (4D+), so we fallback to CPU to ensure 100% coverage. The problem is we cannot use view as it modifies same memory location and values have not materialized in aten_raf_type. Potential fix are:
1. implement matrix folding (similar to pytorch)
2. lower & utilize einsum
3. In raf_node_lowering try reshape + transpositions to convert higher dim matrix. 

## Checklist ##

- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

cc @awslabs/raf-reviewer
