### PR TITLE
[OP] Softmax

### DIFF
--- a/tests/python/op/test_nn.py
+++ b/tests/python/op/test_nn.py
@@ -86,5 +86,19 @@ def test_gelu():
     verify_step(Model(), [x])
 
 
+def test_softmax():
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.softmax = nn.Softmax()
+
+        def forward(self, x_input):
+            return self.softmax(x_input)
+
+    x = torch.randn(3, 3)
+
+    verify_step(Model(), [x], jit_script=False)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Softmax OP lowering. For some reason, the tests only pass when dim = last dim (-1). This can be implicitly inferred, but providing wrong dim causes test to fail (that is why pytest.mark is not provided). I checked in RAF and the axis is also set to -1. 

## Checklist ##

- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

cc @awslabs/raf-reviewer
