### PR TITLE
[OP] Dropout + dropout backward lowering

### DIFF
--- a/raf_native_functions.yaml
+++ b/raf_native_functions.yaml
@@ -306,3 +306,4 @@ supported:
 autograd:
   - max_pool2d
   - max_pool3d
+  - dropout

--- a/ratex/csrc/aten_autograd_ops.h
+++ b/ratex/csrc/aten_autograd_ops.h
@@ -31,5 +31,12 @@ struct MaxPool3dAutogradFunction : public torch::autograd::Function<MaxPool3dAut
                                                  torch::autograd::variable_list grad_output);
 };
 
+struct Dropout : public torch::autograd::Function<Dropout> {
+  static torch::Tensor forward(torch::autograd::AutogradContext* ctx, const at::Tensor& input,
+                               double p, bool train);
+  static torch::autograd::variable_list backward(torch::autograd::AutogradContext* ctx,
+                                                 torch::autograd::variable_list grad_output);
+};
+
 }  // namespace aten_autograd_ops
 }  // namespace torch_lazy_tensors

--- a/ratex/csrc/aten_raf_type.cpp
+++ b/ratex/csrc/aten_raf_type.cpp
@@ -1066,6 +1066,10 @@ at::Tensor LazyNativeFunctions::dot(const at::Tensor& self, const at::Tensor& te
                                                       bridge::raf_backend::GetLtcTensor(tensor)));
 }
 
+at::Tensor LazyNativeFunctions::dropout(const at::Tensor& input, double p, bool train) {
+  return aten_autograd_ops::Dropout::apply(input, p, train);
+}
+
 at::Tensor LazyNativeFunctions::elu(const at::Tensor& self, const at::Scalar& alpha,
                                     const at::Scalar& scale, const at::Scalar& input_scale) {
   LTC_FN_COUNTER("raf::");

--- a/ratex/csrc/ops/dropout_backward.cpp
+++ b/ratex/csrc/ops/dropout_backward.cpp
@@ -22,7 +22,8 @@ namespace ops {
 
 DropoutBackward::DropoutBackward(const Value& grad_output, const Value& mask,
                                  const Value& reserve_space)
-    : Node(raf_dropout_backward, {grad_output, mask, reserve_space}, grad_output.shape(), /*num_outputs=*/1) {
+    : Node(raf_dropout_backward, {grad_output, mask, reserve_space}, grad_output.shape(),
+           /*num_outputs=*/1) {
 }
 
 NodePtr DropoutBackward::Clone(OpList operands) const {

--- a/ratex/csrc/ops/dropout_backward.cpp
+++ b/ratex/csrc/ops/dropout_backward.cpp
@@ -22,7 +22,7 @@ namespace ops {
 
 DropoutBackward::DropoutBackward(const Value& grad_output, const Value& mask,
                                  const Value& reserve_space)
-    : Node(raf_dropout_backward, {grad_output, mask, reserve_space}, grad_output.shape()) {
+    : Node(raf_dropout_backward, {grad_output, mask, reserve_space}, grad_output.shape(), /*num_outputs=*/1) {
 }
 
 NodePtr DropoutBackward::Clone(OpList operands) const {

--- a/ratex/csrc/ops/dropout_backward.cpp
+++ b/ratex/csrc/ops/dropout_backward.cpp
@@ -22,8 +22,9 @@ namespace ops {
 
 DropoutBackward::DropoutBackward(const Value& grad_output, const Value& mask,
                                  const Value& reserve_space)
-    : Node(raf_dropout_backward, {grad_output, mask, reserve_space}, grad_output.shape(),
+    : Node(raf_dropout_backward, {grad_output, mask, reserve_space},
            /*num_outputs=*/1) {
+  SetShapeDeferred([&]() { return compiler::NodeLowering::Get()->Infer(this); });
 }
 
 NodePtr DropoutBackward::Clone(OpList operands) const {

--- a/ratex/csrc/ops/dropout_backward.cpp
+++ b/ratex/csrc/ops/dropout_backward.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ratex/csrc/ops/dropout_backward.h"
+#include "ratex/csrc/ops/raf_ops.h"
+
+#include "absl/strings/str_join.h"
+#include "lazy_tensor_core/csrc/compiler/node_lowering.h"
+#include "lazy_tensor_core/csrc/reduction.h"
+#include "lazy_tensor_core/csrc/tensor_util.h"
+#include "lazy_tensor_core/csrc/torch_util.h"
+#include "lazy_tensors/computation_client/util.h"
+
+#include "lazy_tensors/computation_client/debug_macros.h"
+#include "lazy_tensors/computation_client/util.h"
+
+namespace torch_lazy_tensors {
+namespace ir {
+namespace ops {
+
+DropoutBackward::DropoutBackward(const Value& grad_output, const Value& mask,
+                                 const Value& reserve_space)
+    : Node(raf_dropout_backward, {grad_output, mask, reserve_space}, grad_output.shape()) {
+}
+
+NodePtr DropoutBackward::Clone(OpList operands) const {
+  return MakeNode<DropoutBackward>(operands.at(0), operands.at(1), operands.at(2));
+}
+
+std::string DropoutBackward::ToString() const {
+  std::stringstream ss;
+  ss << Node::ToString();
+  return ss.str();
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_lazy_tensors

--- a/ratex/csrc/ops/dropout_backward.h
+++ b/ratex/csrc/ops/dropout_backward.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "lazy_tensor_core/csrc/ir.h"
+#include "lazy_tensors/types.h"
+
+namespace torch_lazy_tensors {
+namespace ir {
+namespace ops {
+
+class DropoutBackward : public Node {
+ public:
+  DropoutBackward(const Value& grad_output, const Value& mask, const Value& reserve_space);
+
+  NodePtr Clone(OpList operands) const override;
+
+  std::string ToString() const override;
+
+  const double p() const {
+    return p_;
+  };
+
+ private:
+  double p_;
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_lazy_tensors

--- a/ratex/csrc/ops/raf_ops.cpp
+++ b/ratex/csrc/ops/raf_ops.cpp
@@ -12,6 +12,7 @@ namespace ops {
 const OpKindWrapper raf_relay_expr("ratex::relay_expr");
 const OpKindWrapper raf_relay_function("ratex::relay_function");
 const OpKindWrapper raf_log_softmax_backward_use_in("ratex::log_softmax_backward_use_in");
+const OpKindWrapper raf_dropout_backward("razor::dropout_backward");
 
 }  // namespace ops
 }  // namespace ir

--- a/ratex/csrc/ops/raf_ops.h
+++ b/ratex/csrc/ops/raf_ops.h
@@ -17,6 +17,7 @@ namespace ops {
 extern const OpKindWrapper raf_relay_expr;
 extern const OpKindWrapper raf_relay_function;
 extern const OpKindWrapper raf_log_softmax_backward_use_in;
+extern const OpKindWrapper raf_dropout_backward;
 
 }  // namespace ops
 }  // namespace ir

--- a/ratex/lazy_tensor_core/csrc/ops/dropout.cpp
+++ b/ratex/lazy_tensor_core/csrc/ops/dropout.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "lazy_tensor_core/csrc/ops/dropout.h"
+
+#include "lazy_tensor_core/csrc/compiler/node_lowering.h"
+#include "lazy_tensors/computation_client/debug_macros.h"
+#include "lazy_tensors/computation_client/util.h"
+
+namespace torch_lazy_tensors {
+namespace ir {
+namespace ops {
+
+Dropout::Dropout(const Value& input, double p)
+    : Node(ir::OpKind(at::aten::dropout), {input}, 3, lazy_tensors::util::MHash(p)), p_(p) {
+  SetShapeDeferred([&]() { return compiler::NodeLowering::Get()->Infer(this); });
+}
+
+NodePtr Dropout::Clone(OpList operands) const {
+  return MakeNode<Dropout>(operands.at(0), p_);
+}
+
+std::string Dropout::ToString() const {
+  std::stringstream ss;
+  ss << Node::ToString() << " p=" << p_;
+  return ss.str();
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_lazy_tensors

--- a/ratex/lazy_tensor_core/csrc/ops/dropout.h
+++ b/ratex/lazy_tensor_core/csrc/ops/dropout.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "lazy_tensor_core/csrc/ir.h"
+
+namespace torch_lazy_tensors {
+namespace ir {
+namespace ops {
+
+class Dropout : public Node {
+ public:
+  Dropout(const Value& input, double p);
+
+  NodePtr Clone(OpList operands) const override;
+
+  std::string ToString() const override;
+
+  const double p() const {
+    return p_;
+  };
+
+ private:
+  double p_;
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_lazy_tensors

--- a/ratex/lazy_tensor_core/csrc/tensor.h
+++ b/ratex/lazy_tensor_core/csrc/tensor.h
@@ -439,6 +439,12 @@ class LazyTensor {
   // matrix dimensions are specified by dim1 and dim2, the diagonal by offset.
   static LazyTensor diagonal(const LazyTensor& input, int64_t offset, int64_t dim1, int64_t dim2);
 
+  static std::tuple<LazyTensor, LazyTensor, LazyTensor> dropout(const LazyTensor& input, double p,
+                                                                c10::optional<bool> train);
+
+  static LazyTensor dropout_backward(const LazyTensor& dy, const LazyTensor& mask,
+                                     const LazyTensor& reserve_space);
+
   static LazyTensor div(const LazyTensor& input, const LazyTensor& other,
                         const c10::optional<c10::string_view>& = c10::nullopt,
                         c10::optional<at::ScalarType> logical_element_type = c10::nullopt);

--- a/ratex/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/ratex/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -49,6 +49,8 @@
 #include "lazy_tensor_core/csrc/ops/device_data.h"
 #include "lazy_tensor_core/csrc/ops/diagonal.h"
 #include "lazy_tensor_core/csrc/ops/discrete_uniform.h"
+#include "lazy_tensor_core/csrc/ops/dropout.h"
+#include "ratex/csrc/ops/dropout_backward.h"
 #include "lazy_tensor_core/csrc/ops/expand.h"
 #include "lazy_tensor_core/csrc/ops/exponential.h"
 #include "lazy_tensor_core/csrc/ops/embedding.h"
@@ -990,6 +992,22 @@ LazyTensor LazyTensor::div(const LazyTensor& input, const at::Scalar& other) {
   ir::Value other_value =
       GetIrValueForScalar(other, input_value.shape().element_type(), input.GetDevice());
   return input.CreateFrom(input_value / other_value, scalar_type);
+}
+
+std::tuple<LazyTensor, LazyTensor, LazyTensor> LazyTensor::dropout(const LazyTensor& input,
+                                                                   double p,
+                                                                   c10::optional<bool> train) {
+  ir::NodePtr node = ir::MakeNode<ir::ops::Dropout>(input.GetIrValue(), p);
+  auto output = input.CreateFrom(ir::Value(node, 0));
+  auto mask = input.CreateFrom(ir::Value(node, 1));
+  auto reserve_space = input.CreateFrom(ir::Value(node, 2));
+  return std::make_tuple(std::move(output), std::move(mask), std::move(reserve_space));
+}
+
+LazyTensor LazyTensor::dropout_backward(const LazyTensor& dy, const LazyTensor& mask,
+                                        const LazyTensor& reserve_space) {
+  return dy.CreateFrom(ir::MakeNode<ir::ops::DropoutBackward>(dy.GetIrValue(), mask.GetIrValue(),
+                                                              reserve_space.GetIrValue()));
 }
 
 LazyTensor LazyTensor::eq(const LazyTensor& input, const at::Scalar& other) {

--- a/tests/python/op/test_nn.py
+++ b/tests/python/op/test_nn.py
@@ -101,9 +101,9 @@ def test_embedding(dtype, norm_type):
     verify_step(Model(), [x], jit_script=False)
 
 
-# @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
-@pytest.mark.parametrize("p", [0.1, 0.2, 0.4, 0.6])
-def test_dropout(p):
+@pytest.mark.parametrize("dtype", [torch.float32])
+@pytest.mark.parametrize("p", [0.2, 0.6])
+def test_dropout(p, dtype):
     class Model(nn.Module):
         def __init__(self):
             super().__init__()
@@ -125,14 +125,14 @@ def test_dropout(p):
             check(expected, dx)
 
     shape = (128, 128)
-    t_x_ratex = torch.randn(*shape, requires_grad=True).to("lazy")
+    t_x_ratex = torch.randn(*shape, dtype=dtype, requires_grad=True).to("lazy")
     model = Model()
     out = model(t_x_ratex)
 
     check_dropout(t_x_ratex, out)
 
     d_x = np.random.randn(*shape)
-    dy = torch.tensor(d_x, device="lazy", dtype=torch.float32, requires_grad=True)
+    dy = torch.tensor(d_x, device="lazy", dtype=dtype, requires_grad=True)
 
     out.backward(dy)
 

--- a/tests/python/op/test_nn.py
+++ b/tests/python/op/test_nn.py
@@ -7,6 +7,7 @@ import torch.nn as nn
 
 import ratex
 from ratex.testing import verify_step
+import random
 
 
 def test_conv():

--- a/tests/python/op/test_nn.py
+++ b/tests/python/op/test_nn.py
@@ -7,7 +7,6 @@ import torch.nn as nn
 
 import ratex
 from ratex.testing import verify_step
-import random
 
 
 def test_conv():

--- a/tests/python/op/test_nn.py
+++ b/tests/python/op/test_nn.py
@@ -4,9 +4,9 @@
 import pytest
 import torch
 import torch.nn as nn
-
+import numpy as np
 import ratex
-from ratex.testing import verify_step
+from ratex.testing import verify_step, check
 
 
 def test_conv():
@@ -100,6 +100,43 @@ def test_embedding(dtype, norm_type):
     x = torch.randint(10, (3, 3))
     verify_step(Model(), [x], jit_script=False)
 
+# @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+@pytest.mark.parametrize("p", [.1, .2, .4, .6])
+def test_dropout(p):
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.dropout = nn.Dropout(p=p)
+
+        def forward(self, x_input):
+            return self.dropout(x_input)
+
+    def check_dropout(x, y, dx=None, dy=None):
+        x, y = x.numpy(), y.numpy()
+        mask = y != 0
+        expected = mask * x / (1 - p)
+        check(expected, y)
+        frac = np.sum(y == 0) / y.size
+        assert p - 0.1 < frac < p + 0.1
+        if dx is not None and dy is not None:
+            dx, dy = dx.numpy(), dy.numpy()
+            expected = mask / (1 - p) * dy
+            check(expected, dx)
+
+    shape = (128,128)
+    n_x = np.random.randn(*shape)
+    t_x_ratex = torch.tensor(n_x, device="lazy", dtype=torch.float32, requires_grad=True)
+    model = Model()
+    out = model(t_x_ratex)
+
+    check_dropout(t_x_ratex, out)
+
+    d_x = np.random.randn(*shape)
+    dy = torch.tensor(d_x, device="lazy", dtype=torch.float32, requires_grad=True)
+
+    out.backward(dy)
+
+    check_dropout(t_x_ratex, out, t_x_ratex.grad, dy)
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Lower dropout using custom autograd dispatch to raf.contrib_dropout. No test case as dropout randomly drops values from tensor so test case would fail (I tried using torch.manual_seed/numpy seed/ random seed/etc. no luck). 

## Checklist ##

- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

cc @awslabs/raf-reviewer @zachzzc 
