### PR TITLE
[Script] Fix script module inference

### DIFF
--- a/docs/lenet.py
+++ b/docs/lenet.py
@@ -45,7 +45,9 @@ class TorchLeNet(nn.Module):
 
 
 def train(device, model, image_datasets):
-    dataloaders = torch.utils.data.DataLoader(image_datasets, batch_size=1, shuffle=False, num_workers=1)
+    dataloaders = torch.utils.data.DataLoader(
+        image_datasets, batch_size=1, shuffle=False, num_workers=1
+    )
     dataset_size = len(image_datasets)
     model.train()
     criterion = lambda pred, true: nn.functional.nll_loss(nn.LogSoftmax(dim=-1)(pred), true)
@@ -90,7 +92,9 @@ def train(device, model, image_datasets):
 
 
 def infer(device, model, image_datasets):
-    dataloader = torch.utils.data.DataLoader(image_datasets, batch_size=1, shuffle=False, num_workers=1)
+    dataloader = torch.utils.data.DataLoader(
+        image_datasets, batch_size=1, shuffle=False, num_workers=1
+    )
     dataset_size = len(image_datasets)
     model.eval()
     model = model.to(device)
@@ -145,5 +149,4 @@ def main():
 
 
 if __name__ == "__main__":
-     main()
-
+    main()

--- a/docs/lenet.py
+++ b/docs/lenet.py
@@ -57,9 +57,6 @@ def train(device, model, image_datasets):
     model = model.to(device, dtype=torch.float32)
     optimizer = optim.SGD(model.parameters(), lr=0.001)
 
-    import pdb
-    pdb.set_trace()
-
     for epoch in range(num_epochs):
         print("Epoch {}/{}".format(epoch, num_epochs - 1))
         print("-" * 10)
@@ -137,14 +134,14 @@ def main():
     }
     print("raf starts...")
     model_raf = train("lazy", model_raf, image_datasets["train"])
-    #print("cpu starts...")
-    #train("cpu", model_cpu, image_datasets["train"])
+    print("cpu starts...")
+    train("cpu", model_cpu, image_datasets["train"])
 
-    #print("raf starts...")
-    infer("cpu", model_raf, image_datasets["test"])
+    print("raf starts...")
+    infer("cpu", model_raf.native_cpu(), image_datasets["test"])
 
     # statistics
-    #print(metrics.metrics_report())
+    print(metrics.metrics_report())
 
 
 if __name__ == "__main__":

--- a/ratex/jit/script.py
+++ b/ratex/jit/script.py
@@ -17,7 +17,7 @@ import _RATEXC
 
 from .._lib import raf
 from ..value import ValueToHandle
-from ..utils.utils import ltc_timed
+from ..utils.utils import ltc_timed, to_raf_name, to_torch_name
 from ..utils.cache import cache as persist_cache
 
 # pylint: disable=invalid-name
@@ -35,20 +35,6 @@ TORCH_DTYPES = {
     "float32": torch.float32,
     "float64": torch.float64,
 }
-
-
-def to_torch_name(name):
-    """Transform the parameter naming style to PyTorch."""
-    if name.startswith("model_"):
-        assert name.startswith("model_")
-        name = name[len("model_") :]
-        name = name.replace("_", ".")
-    return name
-
-
-def to_raf_name(name):
-    """Transform the parameter naming style to RAF."""
-    return "model_" + name.replace(".", "_")
 
 
 def get_positional_args(param_names, *args, **kwargs):
@@ -285,33 +271,6 @@ def convert_module_to_raf(module, shape_n_dtype, args):
 # Module based cache that maps the input shape/dtype to a tuple of
 # (processed Relay function, function parameter names, inplace update map).
 JIT_CACHE = {}
-
-
-def getattr_recursive(obj, attr_str):
-    """Recursively get an attribute from an object.
-
-    Parameters
-    ----------
-    obj : Object
-        The object to get attribute from.
-
-    attr_str : str
-        The attribute string, e.g. "conv1.weight".
-
-    Returns
-    -------
-    obj : Object
-        The attribute object.
-    """
-    attrs = attr_str.split(".")
-    for attr in attrs:
-        try:
-            obj = getattr(obj, attr)
-        except AttributeError:
-            raise AttributeError(
-                "Attribute {} not found in object of type {}".format(attr, type(obj))
-            ) from None
-    return obj
 
 
 def script(module: torch.nn.Module):

--- a/ratex/lazy_tensor_core/csrc/tensor.cpp
+++ b/ratex/lazy_tensor_core/csrc/tensor.cpp
@@ -18,8 +18,6 @@
 #include <stdexcept>
 #include <unordered_set>
 
-#include <raf/registry.h>
-
 #include "absl/memory/memory.h"
 #include "absl/strings/str_join.h"
 #include "lazy_tensor_core/csrc/debug_util.h"
@@ -1510,7 +1508,6 @@ LazyTensor::CompilationResult LazyTensor::Compile(const std::vector<LazyTensor>&
 std::shared_ptr<LazyTensor::Async> LazyTensor::SyncTensorsGraphInternal(
     std::vector<LazyTensor>* tensors, lazy_tensors::Span<const std::string> devices,
     const SyncTensorsConfig& config) {
-  LTC_COUNTER("SyncTensorsGraphInternal", 1);
   SyncTensorCollection coll = CollectSyncTensors(*tensors, config);
   if (coll.indices.empty()) {
     return nullptr;

--- a/ratex/lazy_tensor_core/csrc/tensor.cpp
+++ b/ratex/lazy_tensor_core/csrc/tensor.cpp
@@ -18,6 +18,8 @@
 #include <stdexcept>
 #include <unordered_set>
 
+#include <raf/registry.h>
+
 #include "absl/memory/memory.h"
 #include "absl/strings/str_join.h"
 #include "lazy_tensor_core/csrc/debug_util.h"
@@ -1508,6 +1510,7 @@ LazyTensor::CompilationResult LazyTensor::Compile(const std::vector<LazyTensor>&
 std::shared_ptr<LazyTensor::Async> LazyTensor::SyncTensorsGraphInternal(
     std::vector<LazyTensor>* tensors, lazy_tensors::Span<const std::string> devices,
     const SyncTensorsConfig& config) {
+  LTC_COUNTER("SyncTensorsGraphInternal", 1);
   SyncTensorCollection coll = CollectSyncTensors(*tensors, config);
   if (coll.indices.empty()) {
     return nullptr;

--- a/ratex/testing/common.py
+++ b/ratex/testing/common.py
@@ -277,6 +277,7 @@ def train(
     set_to_none=True,
     acc_grad_steps=None,
     force_one_hot=True,
+    return_model=False,
 ):
     """Run training."""
     if optimizer_params is None:
@@ -331,7 +332,7 @@ def train(
         end = time.time()
         logger.debug("Epoch %2d, Loss %.4f, Time %.4f", epoch, epoch_loss, (end - start))
         results.append(epoch_loss)
-    return results
+    return results if not return_model else (results, model)
 
 
 def verify(lazy_results, cpu_results, tol=1e-5):

--- a/ratex/utils/utils.py
+++ b/ratex/utils/utils.py
@@ -56,6 +56,20 @@ def ltc_counter(name, value=1):
     _RATEXC._raf_ltc_counter_metric(name, value)
 
 
+def to_torch_name(name):
+    """Transform the parameter naming style to PyTorch."""
+    if name.startswith("model_"):
+        assert name.startswith("model_")
+        name = name[len("model_") :]
+        name = name.replace("_", ".")
+    return name
+
+
+def to_raf_name(name):
+    """Transform the parameter naming style to RAF."""
+    return "model_" + name.replace(".", "_")
+
+
 @tvm._ffi.register_func("ratex.utils.print_stack")
 def print_stack():
     """Print stack trace."""


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##

After #36, `ratex.jit.script` returns a PyTorch module instead of a function. The side effect is this ScriptModule decouples from the original PyTorch module along with parameters. As a result, the current practice for inference after training doesn't work anymore:

```python
model = # get PyTorch model
lm_model = ratex.jit.script(model)
lm_model.to("lazy")
optimizer = SGD(lm_model.parameters(), ...)
# training

model.eval().cpu()
inputs = inputs.cpu()
output = model(inputs) # Didn't use the trained weights.
```

On the other hand, since ScriptModule's forward function is customized only for Ratex, the following also doesn't work:

```python
lm_model.eval().cpu()
output = lm_model(inputs) # It still uses Ratex and attempts to run on GPU.
```

I was attempting to keep the original module, so that we could

```python
def __init__(self, module):
    self.native_module = module

def forward(self, *args, **kwargs):
  if args[0].device.type == "lazy":
    return self._lazy_forward(*args, **kwargs)
  return self.native_module(*args, **kwargs)
```

But this is problematic. Specifically, in this way the original module becomes a child of ScriptModule, and somehow PyTorch will constantly visit its forward functions recursively. This results in parameters not being updated during training.

Finally, in this PR, I use a workaround by introducing an API `native_cpu` that copies the trained parameters from ScriptModule to the native PyTorch module. The downside is this API cannot override any existing PyTorch module method (otherwise PyTorch may call it in unexpected scenarios), so users have to explicitly call `model = lm_model.native_cpu()` to trigger this mapping.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer @hgt312 @hzfan 
