### PR TITLE
[OP] Native Layernorm & Native LayerNormBackward Operators

### DIFF
--- a/raf_native_functions.yaml
+++ b/raf_native_functions.yaml
@@ -303,6 +303,8 @@ supported:
   - sigmoid_backward
   - tanh_backward
   - ger
+  - native_layer_norm
+  - native_layer_norm_backward
 autograd:
   - max_pool2d
   - max_pool3d

--- a/ratex/csrc/compiler/raf_node_lowering.cpp
+++ b/ratex/csrc/compiler/raf_node_lowering.cpp
@@ -70,6 +70,8 @@
 #include "lazy_tensor_core/csrc/ops/mse_loss_backward.h"
 #include "lazy_tensor_core/csrc/ops/native_batch_norm_backward.h"
 #include "lazy_tensor_core/csrc/ops/native_batch_norm_forward.h"
+#include "lazy_tensor_core/csrc/ops/native_layer_norm.h"
+#include "lazy_tensor_core/csrc/ops/native_layer_norm_backward.h"
 #include "lazy_tensor_core/csrc/ops/nll_loss.h"
 #include "lazy_tensor_core/csrc/ops/nll_loss2d.h"
 #include "lazy_tensor_core/csrc/ops/nll_loss2d_backward.h"
@@ -249,6 +251,7 @@ class RAFNodeLowering : public NodeLowering {
   DECLARE_OP2(Mean);
   DECLARE_OP2(SoftmaxBackward);
   DECLARE_OP2(Softmax);
+  DECLARE_OP2(NativeLayerNorm);
   lazy_tensors::Shape InferNe(const ir::Node* node);
   lazy_tensors::Shape InferEq(const ir::Node* node);
   lazy_tensors::Shape InferGt(const ir::Node* node);
@@ -282,6 +285,7 @@ class RAFNodeLowering : public NodeLowering {
   lazy_tensors::Shape InferConvolutionOverrideable(const ir::ops::ConvolutionOverrideable* node);
   lazy_tensors::Shape InferEmbedding(const ir::ops::Embedding* node);
   lazy_tensors::Shape InferMean(const ir::ops::Mean* node);
+  lazy_tensors::Shape InferNativeLayerNorm(const ir::ops::NativeLayerNorm* node);
 };
 
 #undef DECLARE_OP2
@@ -359,6 +363,7 @@ Var RAFNodeLowering::LowerToRAF(const ir::Node* node) {
     HANDLE_GENERIC_OP2(Mean, at::aten::mean)
     HANDLE_GENERIC_OP2(Softmax, at::aten::softmax)
     HANDLE_GENERIC_OP2(SoftmaxBackward, at::aten::_softmax_backward_data)
+    HANDLE_GENERIC_OP2(NativeLayerNorm, at::aten::layer_norm)
     case at::prim::Constant: {
       // TODO(asuhan): rework to remove ambiguity between Scalar and Constant
       // nodes to make dynamic_cast unnecessary.
@@ -922,6 +927,23 @@ Var RAFNodeLowering::LowerLogSoftmaxBackwardUseIn(const ir::ops::LogSoftmaxBackw
   }
   return BuildLogSoftmaxBackwardUseIn(ops, node);
 }
+ 
+Var BuildNativeLayerNorm(const std::vector<Var>& ops, const ir::ops::NativeLayerNorm* node) {
+  LTC_CHECK_EQ(ops.size(), 3U);
+  Var x = ops[0];
+  Var scale = ops[1];
+  Var bias = ops[2];
+  Expr axis = MakeConstant(Int(node->normalized_shape().size()));
+  Expr eps = MakeConstant(Double(node->eps()));
+  return BindSymbol(raf::ir::Call(Op::Get("raf.op.layer_norm_train"), {x, scale, bias, axis, eps}));
+}
+
+Var RAFNodeLowering::LowerNativeLayerNorm(const ir::ops::NativeLayerNorm* node) {
+  std::vector<Var> ops;
+  for (const auto& op : node->operands()) ops.push_back(loctx()->GetOutputOp(op));
+  return BuildNativeLayerNorm(ops, node);
+}
+
 
 Var BuildPermute(const std::vector<Var>& ops, const ir::ops::Permute* node) {
   LTC_CHECK_EQ(node->num_outputs(), 1);
@@ -1495,6 +1517,10 @@ lazy_tensors::Shape RAFNodeLowering::Infer(const ir::Node* node) {
     case at::aten::lt: {
       return InferLt(node);
     }
+    case at::aten::layer_norm: {
+      return InferNativeLayerNorm(
+          ir::NodeCast<ir::ops::NativeLayerNorm>(node, ir::OpKind(at::aten::layer_norm)));
+    }
     default: {
       if (kind == *ir::ops::ltc_generic_slice) {
         return InferGenericSlice(
@@ -1780,6 +1806,16 @@ lazy_tensors::Shape RAFNodeLowering::InferEmbedding(const ir::ops::Embedding* no
     ops.push_back(MakeVar("operand", ToRAFType(x.shape())));
   }
   Var out = BuildEmbedding(ops, node);
+  Expr body = InferType(ExtractBinding(out, ops));
+  return ToLTCShape(body->checked_type());
+}
+
+lazy_tensors::Shape RAFNodeLowering::InferNativeLayerNorm(const ir::ops::NativeLayerNorm* node) {
+  std::vector<Var> ops;
+  for (const auto& x : node->operands()) {
+    ops.push_back(MakeVar("operand", ToRAFType(x.shape())));
+  }
+  Var out = BuildNativeLayerNorm(ops, node);
   Expr body = InferType(ExtractBinding(out, ops));
   return ToLTCShape(body->checked_type());
 }

--- a/ratex/lazy_tensor_core/csrc/ops/native_layer_norm.cpp
+++ b/ratex/lazy_tensor_core/csrc/ops/native_layer_norm.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "lazy_tensor_core/csrc/ops/native_layer_norm.h"
+
+#include "lazy_tensors/computation_client/debug_macros.h"
+
+#include "lazy_tensor_core/csrc/compiler/node_lowering.h"
+#include "lazy_tensors/computation_client/util.h"
+
+namespace torch_lazy_tensors {
+namespace ir {
+namespace ops {
+//NativeLayerNorm Node
+NativeLayerNorm::NativeLayerNorm(const Value& input, std::vector<int64_t> normalized_shape, const Value& weight, const Value& bias, double eps)
+    : Node(ir::OpKind(at::aten::layer_norm), {input, weight, bias}, 3), normalized_shape_(normalized_shape), eps_(eps){
+    SetShapeDeferred([&]() { return compiler::NodeLowering::Get()->Infer(this); });
+}
+
+NodePtr NativeLayerNorm::Clone(OpList operands) const {
+  return MakeNode<NativeLayerNorm>(operands.at(0), normalized_shape_, operands.at(1), operands.at(2), eps_);
+}
+
+std::string NativeLayerNorm::ToString() const {
+  std::stringstream ss;
+  ss << Node::ToString() << "normalized_shape= "<< normalized_shape_ << "eps= " << eps_;
+  return ss.str();
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_lazy_tensors

--- a/ratex/lazy_tensor_core/csrc/ops/native_layer_norm.h
+++ b/ratex/lazy_tensor_core/csrc/ops/native_layer_norm.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "lazy_tensor_core/csrc/ir.h"
+#include "lazy_tensor_core/csrc/compiler/node_lowering.h"
+#include "lazy_tensors/computation_client/util.h"
+
+namespace torch_lazy_tensors {
+namespace ir {
+namespace ops {
+//Node for the native_layer_norm operator.
+class NativeLayerNorm : public Node {
+ public:
+  NativeLayerNorm(const Value& input,std::vector<int64_t> normalized_shape, const Value& weight, const Value& bias, double eps);
+
+  NodePtr Clone(OpList operands) const override;
+
+  std::string ToString() const override;
+
+  std::vector<int64_t> normalized_shape() const {
+    return normalized_shape_;
+  }
+
+  double eps() const {
+    return eps_;
+  }
+
+
+ private:
+  std::vector<int64_t> normalized_shape_;
+  double eps_;
+
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_lazy_tensors

--- a/ratex/lazy_tensor_core/csrc/ops/native_layer_norm_backward.cpp
+++ b/ratex/lazy_tensor_core/csrc/ops/native_layer_norm_backward.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018 Google Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Modifications Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "lazy_tensor_core/csrc/ops/native_layer_norm_backward.h"
+
+#include "lazy_tensor_core/csrc/compiler/node_lowering.h"
+#include "lazy_tensors/computation_client/debug_macros.h"
+#include "lazy_tensors/computation_client/util.h"
+
+namespace torch_lazy_tensors {
+namespace ir {
+namespace ops {
+
+NativeLayerNormBackward::NativeLayerNormBackward(const Value& grad_out, const Value& input, std::vector<int64_t> normalized_shape,
+                                                const Value& mean, const Value& rstd, const Value& weight, const Value& bias
+                                                )
+    : Node(ir::OpKind(at::aten::native_layer_norm_backward),
+           {grad_out, input, mean, rstd, weight, bias}, /*num_outputs=*/3, lazy_tensors::util::MHash(normalized_shape)), normalized_shape_(normalized_shape)
+            {
+  SetShapeDeferred([&]() { return compiler::NodeLowering::Get()->Infer(this); });
+}
+
+NodePtr NativeLayerNormBackward::Clone(OpList operands) const {
+  return MakeNode<NativeLayerNormBackward>(operands.at(0), operands.at(1), normalized_shape_,
+                                           operands.at(2), operands.at(3), operands.at(4), operands.at(5));
+}
+
+std::string NativeLayerNormBackward::ToString() const {
+  std::stringstream ss;
+  ss << Node::ToString() << "normalized_shape= "<< normalized_shape_;
+  return ss.str();
+}
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_lazy_tensors

--- a/ratex/lazy_tensor_core/csrc/ops/native_layer_norm_backward.h
+++ b/ratex/lazy_tensor_core/csrc/ops/native_layer_norm_backward.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018 Google Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Modifications Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "lazy_tensor_core/csrc/ir.h"
+#include "lazy_tensor_core/csrc/compiler/node_lowering.h"
+#include "lazy_tensors/computation_client/util.h"
+
+namespace torch_lazy_tensors {
+namespace ir {
+namespace ops {
+
+// Node for the backward_layer_norm operator.
+class NativeLayerNormBackward : public Node {
+ public:
+  NativeLayerNormBackward(const Value& grad_out, const Value& input, std::vector<int64_t> normalized_shape,
+                          const Value& mean, const Value& rstd, const Value& weight, const Value& bias);
+
+  NodePtr Clone(OpList operands) const override;
+
+  std::string ToString() const override;
+
+  std::vector<int64_t> normalized_shape() const {
+    return normalized_shape_;
+  }
+
+  private:
+  std::vector<int64_t> normalized_shape_;
+
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_lazy_tensors

--- a/ratex/lazy_tensor_core/csrc/tensor.h
+++ b/ratex/lazy_tensor_core/csrc/tensor.h
@@ -713,6 +713,14 @@ class LazyTensor {
   static std::tuple<LazyTensor, LazyTensor, LazyTensor> native_batch_norm_backward(
       const LazyTensor& grad_out, const LazyTensor& input, const LazyTensor& weight,
       const LazyTensor& save_mean, const LazyTensor& save_invstd, bool training, double eps);
+  
+   // Returns the input, weight, and bias gradients.
+  static std::tuple<LazyTensor, LazyTensor, LazyTensor> native_layer_norm(const LazyTensor& input, std::vector<int64_t> normalized_shape,
+        const LazyTensor& weight, const LazyTensor& bias, double eps);
+
+  // Like native_layer_norm, but returns additional mean and rstd used by the backward pass. 
+  static std::tuple<LazyTensor, LazyTensor, LazyTensor> native_layer_norm_backward(const LazyTensor& grad_out, const LazyTensor& input, std::vector<int64_t> normalized_shape, 
+          const LazyTensor& mean, const LazyTensor& rstd, const LazyTensor& weight, const LazyTensor& bias);
 
   static LazyTensor ne(const LazyTensor& input, const at::Scalar& other);
 

--- a/ratex/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/ratex/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -84,6 +84,8 @@
 #include "lazy_tensor_core/csrc/ops/mse_loss_backward.h"
 #include "lazy_tensor_core/csrc/ops/native_batch_norm_backward.h"
 #include "lazy_tensor_core/csrc/ops/native_batch_norm_forward.h"
+#include "lazy_tensor_core/csrc/ops/native_layer_norm.h"
+#include "lazy_tensor_core/csrc/ops/native_layer_norm_backward.h
 #include "lazy_tensor_core/csrc/ops/nll_loss.h"
 #include "lazy_tensor_core/csrc/ops/nll_loss2d.h"
 #include "lazy_tensor_core/csrc/ops/nll_loss2d_backward.h"

--- a/ratex/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/ratex/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -1623,6 +1623,26 @@ std::tuple<LazyTensor, LazyTensor, LazyTensor> LazyTensor::native_batch_norm_bac
   LazyTensor grad_bias = input.CreateFrom(ir::Value(node, 2));
   return std::make_tuple(std::move(grad_input), std::move(grad_weight), std::move(grad_bias));
 }
+  
+std::tuple<LazyTensor, LazyTensor, LazyTensor> LazyTensor::native_layer_norm(const LazyTensor& input, std::vector<int64_t> normalized_shape,
+                                  const LazyTensor& weight, const LazyTensor& bias, double eps) {
+    ir::NodePtr node = ir::MakeNode<ir::ops::NativeLayerNorm>(input.GetIrValue(), Helpers::I64List(normalized_shape),
+                                       weight.GetIrValue(), bias.GetIrValue(), eps);
+    return std::make_tuple(input.CreateFrom(ir::Value(node, 0)),
+                         input.CreateFrom(ir::Value(node, 2)), input.CreateFrom(ir::Value(node, 3)));
+}
+
+std::tuple<LazyTensor, LazyTensor, LazyTensor> LazyTensor::native_layer_norm_backward(const LazyTensor& grad_out, const LazyTensor& input, std::vector<int64_t> normalized_shape, 
+                                                const LazyTensor& mean, const LazyTensor& rstd, const LazyTensor& weight,   
+                                                const LazyTensor& bias) {
+  ir::NodePtr node = ir::MakeNode<ir::ops::NativeLayerNormBackward>(
+      grad_out.GetIrValue(), input.GetIrValue(), Helpers::I64List(normalized_shape), mean.GetIrValue(), rstd.GetIrValue(), weight.GetIrValue(), bias.GetIrValue()
+      );
+  LazyTensor grad_input = input.CreateFrom(ir::Value(node, 0));
+  LazyTensor grad_weight = input.CreateFrom(ir::Value(node, 1));
+  LazyTensor grad_bias = input.CreateFrom(ir::Value(node, 2));
+  return std::make_tuple(std::move(grad_input), std::move(grad_weight), std::move(grad_bias));
+} 
 
 LazyTensor LazyTensor::ne(const LazyTensor& input, const at::Scalar& other) {
   return DispatchComparisonOp(at::aten::ne, input, other);

--- a/ratex/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/ratex/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -85,7 +85,7 @@
 #include "lazy_tensor_core/csrc/ops/native_batch_norm_backward.h"
 #include "lazy_tensor_core/csrc/ops/native_batch_norm_forward.h"
 #include "lazy_tensor_core/csrc/ops/native_layer_norm.h"
-#include "lazy_tensor_core/csrc/ops/native_layer_norm_backward.h
+#include "lazy_tensor_core/csrc/ops/native_layer_norm_backward.h"
 #include "lazy_tensor_core/csrc/ops/nll_loss.h"
 #include "lazy_tensor_core/csrc/ops/nll_loss2d.h"
 #include "lazy_tensor_core/csrc/ops/nll_loss2d_backward.h"


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Implemented Native_layer_norm and Native_layer_norm_backward operators. I notice an error from the unit test that may be related to aten and mapping between ratex and raf in raf_node_lowering.cpp.

## Checklist ##

- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

cc @awslabs/raf-reviewer
